### PR TITLE
이제 slack 스레드 id를 통해 chat history를 전달합니다. 

### DIFF
--- a/slack_mcp_client/lambda_function.py
+++ b/slack_mcp_client/lambda_function.py
@@ -2,7 +2,7 @@ import json
 import logging
 import os
 import asyncio # Added
-from typing import Optional, Any, Dict # Added
+from typing import Optional, Any, Dict, List # Added
 from contextlib import AsyncExitStack # Added
 
 import boto3
@@ -17,7 +17,7 @@ logger.setLevel(logging.INFO)
 # --- Bedrock Configuration ---
 boto3_session = boto3.Session() # Consider region_name if needed
 bedrock_runtime = boto3_session.client('bedrock-runtime')
-CLAUDE_MODEL_ID = "us.anthropic.claude-3-7-sonnet-20250219-v1:0"
+CLAUDE_MODEL_ID = "us.anthropic.claude-sonnet-4-20250514-v1:0"
 
 # --- MCP Server Configuration ---
 # Use MCP_SSE_SERVER_URL for the SSE endpoint
@@ -454,6 +454,288 @@ class MCPClient:
         except Exception as e:
             logger.error(f"Error during Bedrock conversation or MCP tool call: {e}", exc_info=True)
             return "Sorry, there was an error processing your request."
+        
+    async def process_query_with_context(self, query: str, channel_id: str, thread_ts: str) -> str:
+        """Process a query with thread context awareness"""
+        if not self.session:
+            logger.error("MCP session is not initialized. Cannot process query.")
+            return "Error: Connection to the tool server is not established."
+
+        # 기본 처리 (컨텍스트 없이)
+        if not thread_ts:
+            # 새 스레드이거나 thread_ts가 없으면 기본 처리
+            return await self.process_query(query, channel_id, thread_ts)
+
+        # 스레드 히스토리 가져오기
+        try:
+            from slack_utils import get_thread_history, format_thread_for_bedrock
+            thread_messages = get_thread_history(channel_id, thread_ts)
+            
+            if not thread_messages or len(thread_messages) <= 1:
+                # 히스토리가 없거나 현재 메시지만 있으면 기본 처리
+                return await self.process_query(query, channel_id, thread_ts)
+            
+            # 대화 히스토리를 Bedrock 형식으로 변환
+            conversation_history = format_thread_for_bedrock(thread_messages)
+            
+            # 현재 쿼리 추가
+            current_message = {
+                "role": "user",
+                "content": [{"text": query}]
+            }
+            
+            # 마지막 메시지가 현재 쿼리와 같으면 제거 (중복 방지)
+            if (conversation_history and 
+                conversation_history[-1]["role"] == "user" and 
+                conversation_history[-1]["content"][0]["text"].strip() == query.strip()):
+                conversation_history = conversation_history[:-1]
+            
+            messages = conversation_history + [current_message]
+            
+            # 컨텍스트를 포함한 시스템 프롬프트
+            system_prompt = [
+                {
+                    "text": "You are a helpful assistant integrated with an MCP system. "
+                            "You have access to the full conversation history in this thread. "
+                            "Use this context to provide more relevant responses. "
+                            "When users refer to 'that instance', 'the volume we discussed', or use other references, "
+                            "use the conversation history to understand what they're referring to. "
+                            "Use the provided tools ONLY when the user's request clearly matches a tool's purpose. "
+                            "When generating your final response after using tools: Your response MUST be based "
+                            "strictly on the results provided in the toolResult messages."
+                }
+            ]
+            
+            # 기존 process_query 로직을 재사용하되 messages만 교체
+            return await self._process_with_bedrock_context(messages, system_prompt, channel_id, thread_ts)
+            
+        except Exception as e:
+            logger.error(f"Error processing with context, falling back to basic processing: {e}")
+            # 컨텍스트 처리 실패 시 기본 처리로 fallback
+            return await self.process_query(query, channel_id, thread_ts)
+
+    async def _process_with_bedrock_context(self, messages: List[dict], system_prompt: List[dict], channel_id: str, thread_ts: str) -> str:
+        """기존 process_query 로직을 재사용하되 messages를 파라미터로 받음"""
+        try:
+            logger.info("Listing tools from MCP session...")
+            response = await self.session.list_tools()
+            available_tools = [{
+                "toolSpec": {
+                    "name": tool.name,
+                    "description": tool.description,
+                    "inputSchema": {
+                        "json": tool.inputSchema
+                    }
+                }
+            } for tool in response.tools]
+            
+            initial_user_message = messages[0] if messages else {"role": "user", "content": [{"text": ""}]}
+
+            # Initial Claude API call
+            logger.info("Making initial call to Bedrock converse API with context.")
+            response = bedrock_runtime.converse(
+                modelId=CLAUDE_MODEL_ID,
+                messages=messages,
+                system=system_prompt,
+                toolConfig={
+                    'tools': available_tools
+                }
+            )
+
+            # Process response and handle tool calls
+            tool_results = []
+            final_text = []
+
+            response_message = response['output']['message']
+            messages.append(response_message)
+            stop_reason = response.get('stopReason')
+            logger.debug(f"Bedrock initial response stop_reason: {stop_reason}, message: {response_message}")
+
+            while stop_reason == 'tool_use':
+                logger.info("Bedrock requested tool use.")
+                tool_use_requests = [
+                    content for content in response_message['content'] if content.get('toolUse')]
+                tool_result_contents = []
+
+                # Create tasks for concurrent tool execution if needed, or run sequentially
+                for tool_request in tool_use_requests:
+                    tool_id = tool_request['toolUse']['toolUseId']
+                    tool_name = tool_request['toolUse']['name']
+                    tool_input = tool_request['toolUse']['input']
+
+                    # Execute tool call via MCP session
+                    logger.info(f"--- Calling MCP tool '{tool_name}' with input: {tool_input} ---")
+                    result = await self.session.call_tool(tool_name, tool_input)
+                    logger.debug(f"--- Raw MCP tool '{tool_name}' result object: {result} ---")
+                    
+                    # --- Handle Tool Result Processing --- 
+                    bedrock_content_for_next_step = None 
+                    slack_payload = None
+                    # Content to be potentially processed by LLM for Slack display
+                    content_for_slack_processing = None 
+                    is_error_result = False
+                    is_json_result = False # Flag to differentiate JSON vs Text for LLM request
+
+                    if result.isError:
+                        is_error_result = True
+                        logger.error(f"Tool execution failed for '{tool_name}': {result.content}")
+                        error_message = str(result.content) if result.content else "Unknown tool execution error"
+                        content_for_slack_processing = error_message # Pass error message for formatting
+                        bedrock_content_for_next_step = [{"text": f"Tool execution failed: {error_message}"}]
+                    
+                    elif result.content and isinstance(result.content, list) and len(result.content) > 0:
+                        first_content_item = result.content[0]
+                        if hasattr(first_content_item, 'text') and isinstance(first_content_item.text, str):
+                            potential_json_string = first_content_item.text
+                            try:
+                                parsed_json = json.loads(potential_json_string)
+                                is_json_result = True
+                                content_for_slack_processing = parsed_json # Pass parsed dict for LLM summary
+                                logger.info(f"--- Parsed JSON from TextContent for tool '{tool_name}' ---")
+                                bedrock_content_for_next_step = [{"json": parsed_json}]
+                            except json.JSONDecodeError:
+                                extracted_text = potential_json_string
+                                content_for_slack_processing = extracted_text # Pass raw text for LLM refinement
+                                logger.info(f"--- Extracted plain text content from tool '{tool_name}' ---")
+                                bedrock_content_for_next_step = [{"text": extracted_text}]
+                        else:
+                             is_error_result = True # Treat unexpected format as error for display
+                             error_text = "Tool returned content in an unexpected list format."
+                             content_for_slack_processing = error_text
+                             logger.warning(f"Tool '{tool_name}' returned list content with unexpected item type: {type(first_content_item)}")
+                             bedrock_content_for_next_step = [{"text": error_text}]
+                    else:
+                        is_error_result = True # Treat unexpected format as error for display
+                        error_text = "Tool returned content in an unexpected format or no content."
+                        content_for_slack_processing = error_text
+                        logger.warning(f"Tool '{tool_name}' returned unexpected content format or empty content: {result.content}")
+                        bedrock_content_for_next_step = [{"text": error_text}]
+
+                    # --- LLM Processing for Slack Display (Refinement for Text ONLY) ---                    
+                    slack_display_content = None
+                    # Only process non-error, non-JSON string results with LLM
+                    if not is_error_result and not is_json_result and isinstance(content_for_slack_processing, str):
+                        logger.info(f"--- Requesting LLM refinement/translation for '{tool_name}' text result ---")
+                        refinement_request_content = [
+                            # Even stricter prompt focusing on exact meaning preservation
+                            {"text": f"The user asked the initial query provided earlier. The tool '{tool_name}' produced the text output below. Your task is ONLY to translate/rephrase the EXACT meaning of the provided text output into the same language as the initial user query. Preserve ALL details and words from the original output, including technical terms or specific actions like 'simulated'. DO NOT add any extra words, phrases, introductions, confirmations, or conversational text. Output ONLY the direct translation/rephrasing of the provided text."},
+                            {"text": f"Tool Output Text:\n```\n{content_for_slack_processing}\n```"}
+                        ]
+                        refinement_messages = [ initial_user_message, {"role": "user", "content": refinement_request_content} ]
+                        try:
+                            refinement_response = bedrock_runtime.converse(modelId=CLAUDE_MODEL_ID, messages=refinement_messages, system=system_prompt)
+                            refinement_output = refinement_response.get('output', {}).get('message', {}).get('content', [])
+                            slack_display_content = "".join([c.get('text', '') for c in refinement_output if 'text' in c]).strip()
+                            if not slack_display_content:
+                                 logger.warning(f"LLM refinement was empty for {tool_name}. Using original text.")
+                                 # Fallback to original text if LLM returns empty
+                                 slack_display_content = content_for_slack_processing 
+                        except Exception as refine_err:
+                            logger.error(f"Failed to get LLM refinement for '{tool_name}': {refine_err}", exc_info=True)
+                            # Fallback to original text on error
+                            slack_display_content = content_for_slack_processing 
+                            
+                    # If not processed by LLM (JSON, error, or LLM failed), use the original content
+                    if slack_display_content is None:
+                         slack_display_content = content_for_slack_processing
+                                   
+                    # --- Format final Slack content using the potentially refined display content ---
+                    # Note: _format_tool_result_for_slack handles dict (JSON) or string formatting
+                    if slack_display_content is not None:
+                         slack_payload = self._format_tool_result_for_slack(tool_name, slack_display_content, is_error_result)
+                    else:
+                         # Should ideally not happen, but as a safety net
+                         logger.error(f"slack_display_content was None for tool {tool_name}. Cannot format message.")
+                         slack_payload = {"text": f"Error displaying result for tool {tool_name}"}
+
+                    # --- Post Formatted Message to Slack --- 
+                    if slack_payload:
+                         try:
+                            logger.info(f"Posting intermediate message for '{tool_name}' to Slack channel {channel_id}")
+                            post_message_to_slack(
+                                channel_id=channel_id, 
+                                text=slack_payload.get("text", "Formatted tool result."), 
+                                blocks=slack_payload.get("blocks"), 
+                                thread_ts=thread_ts
+                            )
+                         except Exception as post_err:
+                            logger.error(f"Failed to post intermediate message to Slack: {post_err}")
+                    # --- End Intermediate Posting ---                       
+                        
+                    # Append the ORIGINAL tool result for Bedrock's next action decision
+                    if bedrock_content_for_next_step:
+                         tool_result_contents.append({
+                            "toolResult": {
+                                "toolUseId": tool_id,
+                                "content": bedrock_content_for_next_step,
+                            }
+                        })
+                    else:
+                         logger.error(f"Could not determine bedrock content for tool '{tool_name}' result. Skipping tool result for this request.")
+
+                # Create the user message containing accumulated tool results for this turn
+                if not tool_result_contents:
+                     logger.warning("No tool results generated for this turn, despite tool_use request.")
+                     
+                tool_result_message = {
+                    "role": "user",
+                    "content": tool_result_contents
+                }
+                messages.append(tool_result_message)
+
+                print(f"--- Tool results: {tool_result_contents} ---")
+
+                # Get next response from Claude
+                logger.info("--- Sending tool results back to Bedrock ---")
+                response = bedrock_runtime.converse(
+                    modelId=CLAUDE_MODEL_ID,
+                    messages=messages,
+                    system=system_prompt, # Re-include system prompt
+                    toolConfig={'tools': available_tools}
+                )
+                response_message = response['output']['message']
+                messages.append(response_message)
+                stop_reason = response.get('stopReason')
+                logger.debug(f"Bedrock response after tool use stop_reason: {stop_reason}, message: {response_message}")
+
+                # Append text content from the new response if any
+                assistant_text_content = [
+                    c.get('text') for c in response_message.get('content', []) if 'text' in c]
+                if assistant_text_content:
+                    # Append intermediate text if desired, or just wait for final response
+                    # final_text.append("\n".join(assistant_text_content))
+                    pass # Often better to just return the final summary
+
+            # Handle final response
+            if stop_reason == 'end_turn':
+                logger.info("Bedrock conversation finished.")
+                assistant_text_content = [
+                    c.get('text') for c in response_message.get('content', []) if 'text' in c]
+                if assistant_text_content:
+                    final_text.append("\n".join(assistant_text_content))
+            else:
+                # Handle other stop reasons like max_tokens, error, etc.
+                logger.warning(f"Bedrock conversation stopped for reason: {stop_reason}. Extracting any available text.")
+                assistant_text_content = [
+                    c.get('text') for c in response_message.get('content', []) if 'text' in c]
+                if assistant_text_content:
+                    final_text.append("\n".join(assistant_text_content))
+                else:
+                    final_text.append("Sorry, the conversation ended unexpectedly.")
+
+            # Join all collected text pieces (if intermediate text was collected)
+            # Or just return the last response's text
+            final_response_text = "\n".join(final_text)
+            if not final_response_text: # Fallback if no text content found
+                 logger.error(f"Could not extract final text response from Claude. Last message: {response_message}")
+                 return "Sorry, I couldn't generate a response."
+
+            logger.info(f"Final response for user: {final_response_text}")
+            return final_response_text
+            
+        except Exception as e:
+            logger.error(f"Error during Bedrock conversation with context: {e}", exc_info=True)
+            return "Sorry, there was an error processing your request with context."
 
 
 # --- Remove old Bedrock call function ---
@@ -473,7 +755,10 @@ async def handle_slack_event_async(slack_event, mcp_client: MCPClient):
         user_id = slack_event.get('user')
         text = slack_event.get('text', '').strip()
         channel_id = slack_event.get('channel')
-        thread_ts = slack_event.get('ts') # Timestamp for threading replies
+        
+        # 스레드 타임스탬프 처리: 스레드 내 메시지면 thread_ts 사용, 아니면 현재 메시지의 ts 사용
+        message_ts = slack_event.get('ts')
+        thread_ts = slack_event.get('thread_ts') or message_ts
 
         # Basic check to prevent processing empty messages
         if not text:
@@ -504,9 +789,9 @@ async def handle_slack_event_async(slack_event, mcp_client: MCPClient):
             post_message_to_slack(channel_id, "Sorry, I'm having trouble connecting to my backend services.", thread_ts=thread_ts)
             return
 
-        # Call MCPClient's process_query, passing channel_id and thread_ts
+        # Call MCPClient's process_query_with_context, passing channel_id and thread_ts
         try:
-            final_response = await mcp_client.process_query(user_query, channel_id, thread_ts)
+            final_response = await mcp_client.process_query_with_context(user_query, channel_id, thread_ts)
             # Post the final response from Bedrock
             post_message_to_slack(channel_id, final_response, thread_ts=thread_ts)
         except Exception as e:
@@ -561,7 +846,8 @@ def lambda_handler(event, context):
                 logger.error(f"Error in async handler: {e}", exc_info=True)
                 # Attempt to notify Slack about the error if channel_id is accessible
                 channel_id = slack_event.get('channel')
-                thread_ts = slack_event.get('ts')
+                message_ts = slack_event.get('ts')
+                thread_ts = slack_event.get('thread_ts') or message_ts
                 if channel_id:
                      try:
                          post_message_to_slack(channel_id, "Sorry, an internal error occurred while processing your request.", thread_ts=thread_ts)


### PR DESCRIPTION
# 🧵 스레드 컨텍스트 인식 기능 추가

## 📝 **개요**

Slack 봇이 스레드 내에서 이전 대화 히스토리를 기억하고 참조할 수 있도록 컨텍스트 인식 기능을 구현했습니다.

## 🎯 **해결하려던 문제**

- 사용자가 "그 인스턴스를 시작해줘", "내가 첫 질문으로 뭐라고 말했었지?" 같은 참조 표현을 사용했을 때 봇이 이해하지 못함
- 각 메시지를 독립적으로 처리하여 대화의 연속성이 없었음

## 🔧 **구현 과정**

### 1️⃣ **첫 번째 시도: 스레드 히스토리 기능 구현**

```python
# slack_utils.py에 추가
def get_thread_history(channel_id: str, thread_ts: str) -> List[dict]
def format_thread_for_bedrock(messages: List[dict]) -> List[dict]

```

```python
# lambda_function.py에 추가
async def process_query_with_context(self, query: str, channel_id: str, thread_ts: str) -> str

```

### 2️⃣ **발견된 문제: 스레드 타임스탬프 처리 오류**

**증상**: 같은 스레드에서 대화하는데도 각 메시지가 다른 스레드로 인식됨

```
첫 번째 메시지: thread 1748075172.738839
두 번째 메시지: thread 1748075248.691379  # 다른 값!

```

**원인 분석**: Slack 스레드 메커니즘 이해 부족

- **루트 메시지**: `thread_ts` 필드가 없고, 자신의 `ts`가 스레드 식별자
- **스레드 내 메시지**: `thread_ts` 필드에 루트 메시지의 `ts` 값 포함

**기존 코드 (잘못된 방식)**:

```python
thread_ts = slack_event.get('ts')  # 항상 현재 메시지의 타임스탬프 사용

```

### 3️⃣ **최종 해결: 올바른 스레드 타임스탬프 처리**

```python
# 올바른 처리 방식
message_ts = slack_event.get('ts')
thread_ts = slack_event.get('thread_ts') or message_ts

```

## ✨ **주요 변경사항**

### 📁 **slack_utils.py**

- `get_thread_history()`: Slack API로 스레드 히스토리 조회
- `format_thread_for_bedrock()`: Slack 메시지를 Bedrock 대화 형식으로 변환
- `clean_slack_message()`: Slack 포맷팅(멘션, 링크 등) 정리

### 📁 **lambda_function.py**

- `process_query_with_context()`: 컨텍스트 기반 쿼리 처리
- `_process_with_bedrock_context()`: 컨텍스트가 포함된 Bedrock 호출
- **스레드 타임스탬프 처리 수정**: `slack_event.get('thread_ts') or message_ts`

## 🧪 **테스트 결과**

### ❌ **수정 전**

```
사용자: "현재 도구 목록 알려줘"
봇: [도구 목록 응답]

사용자: "내가 첫 질문으로 뭐라고 말했었지?"
봇: "죄송합니다. 이것이 우리 대화의 첫 번째 메시지입니다."

```

### ✅ **수정 후 (예상 동작)**

```
사용자: "현재 도구 목록 알려줘"
봇: [도구 목록 응답]

사용자: "내가 첫 질문으로 뭐라고 말했었지?"
봇: "첫 번째 질문은 '현재 도구 목록 알려줘'였습니다."

```
![image](https://github.com/user-attachments/assets/4d7347f1-e024-4b6c-8704-c8346e0d9790)
![image](https://github.com/user-attachments/assets/e636f104-9733-4df0-9cb3-41e30df8c303)



## 🔍 **기술적 개선사항**

1. **컨텍스트 인식**: 스레드 히스토리를 Bedrock에 전달하여 대화 맥락 유지
2. **참조 해결**: "그 인스턴스", "앞서 말한" 등의 표현 이해 가능
3. **메모리 효율성**: 스레드별로만 히스토리 로드 (전체 채널 히스토리 X)
4. **오류 처리**: 히스토리 조회 실패 시 기본 처리로 fallback

## 🚀 **사용자 경험 개선**

- 자연스러운 대화 흐름 지원
- 반복 설명 불필요 (컨텍스트 기반 이해)
- 복잡한 AWS 리소스 관리 작업의 연속성 보장